### PR TITLE
Fix nt35310 driver bug, add RESET signal

### DIFF
--- a/k210.c
+++ b/k210.c
@@ -61,6 +61,7 @@ static void io_mux_init(void)
     fpioa_set_function(38, FUNC_GPIOHS0 + DCX_GPIONUM);
     fpioa_set_function(36, FUNC_SPI0_SS3);
     fpioa_set_function(39, FUNC_SPI0_SCLK);
+    fpioa_set_function(37, FUNC_GPIOHS0 + RST_GPIONUM);
     sysctl_set_spi0_dvp_data(1);
 #else
     fpioa_set_function(8, FUNC_GPIOHS0 + DCX_GPIONUM);

--- a/k210.c
+++ b/k210.c
@@ -39,7 +39,7 @@ static void io_set_power(void)
 
 // overclock and voltageboost suported XD
 //use  to configure core voltage.
-#define CORE_VOLTAGE_GPIONUM 3
+#define CORE_VOLTAGE_GPIONUM (7)
 int set_cpu_freq(uint32_t f){//MHz
   if(f<600){
     gpiohs_set_drive_mode(CORE_VOLTAGE_GPIONUM, GPIO_DM_INPUT);

--- a/nt35310.c
+++ b/nt35310.c
@@ -16,6 +16,7 @@
 #include "nt35310.h"
 #include "gpiohs.h"
 #include "spi.h"
+#include "unistd.h"
 #include "board_config.h"
 
 static void  init_dcx(void)
@@ -34,11 +35,23 @@ static void set_dcx_data(void)
     gpiohs_set_pin(DCX_GPIONUM, GPIO_PV_HIGH);
 }
 
+#if BOARD_LICHEEDAN
+static void init_rst(void)
+{
+    gpiohs_set_drive_mode(RST_GPIONUM, GPIO_DM_OUTPUT);
+    gpiohs_set_pin(RST_GPIONUM, GPIO_PV_LOW);
+    usleep(100000);
+    gpiohs_set_pin(RST_GPIONUM, GPIO_PV_HIGH);
+    usleep(100000);
+}
+#endif
+
 void tft_hard_init(void)
 {
     init_dcx();
     spi_init(SPI_CHANNEL, SPI_WORK_MODE_0, SPI_FF_OCTAL, 8, 0);
 #if BOARD_LICHEEDAN
+    init_rst();
     spi_set_clk_rate(SPI_CHANNEL, 20000000);
 #else
     spi_set_clk_rate(SPI_CHANNEL, 25000000);
@@ -67,7 +80,7 @@ void tft_write_half(uint16_t *data_buf, uint32_t length)
 {
     set_dcx_data();
     spi_init(SPI_CHANNEL, SPI_WORK_MODE_0, SPI_FF_OCTAL, 16, 0);
-    spi_init_non_standard(SPI_CHANNEL, 0/*instrction length*/, 16/*address length*/, 0/*wait cycles*/,
+    spi_init_non_standard(SPI_CHANNEL, 16/*instrction length*/, 0/*address length*/, 0/*wait cycles*/,
                           SPI_AITM_AS_FRAME_FORMAT/*spi address trans mode*/);
     spi_send_data_normal_dma(DMAC_CHANNEL0, SPI_CHANNEL, SPI_SLAVE_SELECT,data_buf, length, SPI_TRANS_SHORT);
 }

--- a/nt35310.h
+++ b/nt35310.h
@@ -96,6 +96,7 @@
 #define INTERFACE_CTL           0xF6
 
 #define DCX_GPIONUM             (2)
+#define RST_GPIONUM             (3)
 
 #define SPI_CHANNEL             0
 #define SPI_SLAVE_SELECT        3


### PR DESCRIPTION
IO_37 connected to LCD_RST

![screenshot from 2019-03-01 22-40-18](https://user-images.githubusercontent.com/394260/53645091-19025680-3c73-11e9-93d0-d93dc1b3800f.png)

This commit ensures that the LCD is properly reset and initialized.